### PR TITLE
- updated formulas to latest tag 1.0.9 which supports build on Mavericks

### DIFF
--- a/asl.rb
+++ b/asl.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Asl < Formula
   homepage 'https://github.com/artcom/asl'
-  version '1.0.8'
+  version '1.0.9'
 
   option 'use-internal-git', 'Use ART+COM internal repository'
   option 'enable-tests', 'build and execute unit tests'
@@ -15,7 +15,7 @@ class Asl < Formula
             end
 
 
-  url git_url, :using => :git, :tag => '1.0.8'
+  url git_url, :using => :git, :tag => '1.0.9'
   head git_url, :using => :git, :branch => 'master'
 
   depends_on 'acmake' => :build

--- a/y60.rb
+++ b/y60.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class Y60 < Formula
   homepage 'http://y60.artcom.de'
-  version "1.0.8"
+  version "1.0.9"
 
   option 'with-gtk', "Enable building g60 and y60jsgtk component"
   option 'with-cryptopp', "Enable building cryptopp component"
@@ -17,7 +17,7 @@ class Y60 < Formula
             else
               'https://github.com/artcom/y60.git'
             end
-  url git_url, :using => :git, :tag => '1.0.8'
+  url git_url, :using => :git, :tag => '1.0.9'
   head git_url, :using => :git, :branch => 'master'
 
   depends_on 'cmake' => :build


### PR DESCRIPTION
- allows brewing y60 on Mavericks without manual intervention
